### PR TITLE
Fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN set -x \
      perl \
      gettext \
      python \
-     py-pip \
+     py2-pip \
   && : "---------- download nginx-upstream-module ----------" \
   && git clone "$NGINX_UPSTREAM_MODULE_URL" /usr/src/nginx_upstream_module \
   && git -C /usr/src/nginx_upstream_module checkout $NGINX_UPSTREAM_MODULE_COMMIT \


### PR DESCRIPTION
+ apk add --no-cache --virtual .run-deps ca-certificates openssl pcre zlib libxslt gd geoip perl gettext python py-pip
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  py-pip (virtual):
    provided by: py2-pip
    required by: